### PR TITLE
Maint/workflows hacks

### DIFF
--- a/.github/auto-assign.yml
+++ b/.github/auto-assign.yml
@@ -1,0 +1,25 @@
+# Set to true to add reviewers to PRs
+addReviewers: true
+
+# Set to 'author' to add PR's author as a assignee
+addAssignees: author
+
+# A list of reviewers to be added to PRs (GitHub user  name)
+reviewers:
+  - Gui-FernandesBR
+  - giovaniceotto
+  - MateusStano
+  - FranzYuri
+  - brunosorban
+  - luimot
+  - MrGribel
+  - ompro07
+  - phmbressan
+
+# A number of reviewers added to the PR
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 2
+
+# A list of keywords to be skipped the process if PR's title include it
+skipKeywords:
+  - wip

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,12 @@
+name: Auto Assign PRs once opened
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bubkoo/auto-assign@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONFIG_FILE: .github/auto-assign.yml


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [X] ReadMe, Docs and GitHub maintenance

## Pull request checklist


- ReadMe, Docs and GitHub maintenance:

  - [X] Spelling has been verified
  - [X] Code docs are working correctly 

## What is the new behavior?

Auto assign reviewers and assignees when PRs are opened

## Does this introduce a breaking change?

- [X] No